### PR TITLE
Enter Key nows open up editing mode for images/image-links/leadBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,17 @@ The up arrow will navigate up the builder element list
 
 The down arrow will navigate down the builder element list
 
-> Left
+> Left or Enter (on parent)
 
 The left arrow will collapse a container
 
-> Right
+> Right or Enter (on parent)
 
 The right arrow will expand a container
+
+> Enter
+
+Will open up the 
 
 ## Contributing
 

--- a/builderKeybinding.js
+++ b/builderKeybinding.js
@@ -62,9 +62,10 @@ javascript: void function() {
 							.last()
 							.trigger('click')
 						.closest('.list-group-item');
-				toggleInteractiveClass(currentElement, true);
+				//toggleInteractiveClass(currentElement, true);
 
 				setCurrentElement(tmpElement);
+				toggleInteractiveClass(currentElement, true);
 			});
 			
 			Mousetrap.bind('space', function (e) {

--- a/builderKeybinding.js
+++ b/builderKeybinding.js
@@ -82,29 +82,19 @@ javascript: void function() {
 				toggleInteractiveClass(currentElement, true);
 			});
 
+
+			Mousetrap.bind('enter', function (e) {
+				if($('.modal.fade.in').is(':visible')){
+					$('.modal.fade.in').find('.btn-primary').trigger('click');
+				} else {
+					currentElement.find('.title').trigger('click');
+				}
+			});
+
 			return false;
 		});
-		// Mousetrap.bind('ctrl+shift+h', function (e) {
-		// 	$('#editable-elements .list-group-item:not(:has(.indent)) .controls .glyphicon-eye-open').each(function (idx) {
-		// 		console.log('idx: ', 500 * idx);
-		// 		setTimeout(function () {
-		// 			$(this).trigger('click');
-		// 		}, 2000 * idx);
-		// 	});
-		// 	return false;
-		// });
-		// Mousetrap.bind('ctrl+shift+s', function (e) {
-		// 	$('#editable-elements .list-group-item:not(:has(.indent)) .controls .glyphicon-eye-close').each(function (idx) {
+		
 
-		// 		$(this).trigger('click');
-		// 	});
-		// 	return false;
-		// });
-		// Mousetrap.bind('ctrl+shift+e', function (e) {
-		// 	$('.list-group-item .icon .expand.fa-plus-square').trigger('click');
-		// 	console.log('clicking plus');
-		// 	return false;
-		// });
 	}, 2000);
 
 }();


### PR DESCRIPTION
Text Editing mode is not working correctly yet. That's the next step. But now images, links, or any element that shows a modal should work correctly. Also fixed when collapsing with the Left arrow, previously selected child element was still highlighted and the parent was not highlighted.
